### PR TITLE
Delete for Future Training Programs

### DIFF
--- a/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
@@ -189,7 +189,9 @@ namespace BangazonWorkforce.Controllers
         // GET: TrainingPrograms/Delete/5
         public ActionResult Delete(int id)
         {
-            return View();
+            TrainingProgram trainingProgram = GetTrainingProgramById(id);
+
+            return View(trainingProgram);
         }
 
         // POST: TrainingPrograms/Delete/5

--- a/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
@@ -195,15 +195,26 @@ namespace BangazonWorkforce.Controllers
         }
 
         // POST: TrainingPrograms/Delete/5
-        [HttpPost]
+        [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
-        public ActionResult Delete(int id, IFormCollection collection)
+        public ActionResult DeleteConfirmed(int id, IFormCollection collection)
         {
             try
             {
-                // TODO: Add delete logic here
+                using (SqlConnection conn = Connection)
+                {
+                    conn.Open();
+                    using (SqlCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = @"DELETE FROM EmployeeTraining WHERE TrainingProgramId = @id; 
+                                            DELETE FROM TrainingProgram WHERE Id=@id";
 
-                return RedirectToAction(nameof(Index));
+                        cmd.Parameters.Add(new SqlParameter("@id", id));
+                        cmd.ExecuteNonQuery();
+
+                        return RedirectToAction(nameof(Index));
+                    }
+                }
             }
             catch
             {

--- a/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
@@ -76,6 +76,7 @@ namespace BangazonWorkforce.Controllers
            
         }
 
+        // Gets details of a training program the user selects on the index view. This method accepts one parameter: the training program id.
         // GET: TrainingPrograms/Details/5
         public ActionResult Details(int id)
         {
@@ -103,7 +104,7 @@ namespace BangazonWorkforce.Controllers
             return View();
         }
 
-        // This makes a post to the TrainingProgram table in the BangazonAPI database
+        // This makes a post to the TrainingProgram table in the BangazonAPI database. This method takes one parameter: A TrainingProgram object that is built with the form inputs
         // POST: TrainingPrograms/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -141,6 +142,7 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
+        // Initial Edit(get) method, this gets the training program the user wants to edit and passes it down to the edit view. This method accepts one parameter: the trainingprogram id
         // GET: TrainingPrograms/Edit/5
         public ActionResult Edit(int id)
         {
@@ -149,6 +151,7 @@ namespace BangazonWorkforce.Controllers
             return View(trainingProgram);
         }
 
+        // The UPDATE functionality for editing training programs. This method accepts two parameters: The updated TrainingProgram id, and the TrainingProgram built with the form inputs
         // POST: TrainingPrograms/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -185,7 +188,7 @@ namespace BangazonWorkforce.Controllers
                 return View();
             }
         }
-
+        // This gets the training program by Id and then passes it down to the delete view.
         // GET: TrainingPrograms/Delete/5
         public ActionResult Delete(int id)
         {
@@ -194,6 +197,7 @@ namespace BangazonWorkforce.Controllers
             return View(trainingProgram);
         }
 
+        // This is the functionality of the delete, this method makes sure to delete all the items in the EmployeeTraining join table first, then deletes the training program.
         // POST: TrainingPrograms/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
@@ -222,6 +226,7 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
+        // This method will be used to get a certain training program by Id. This private method is used in Details, Edit (get), and Delete(get). This method accepts one parameter: the training program id
         private TrainingProgram GetTrainingProgramById(int id)
         {
             using (SqlConnection conn = Connection)

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Create.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Create.cshtml
@@ -1,4 +1,7 @@
-﻿@model BangazonWorkforce.Models.TrainingProgram
+﻿@*Author: Chris Morgan
+The purpose of the training program create view is to render a form that the user can fill out to create a new training program*@
+
+@model BangazonWorkforce.Models.TrainingProgram
 
 @{
     ViewData["Title"] = "Create";

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Delete.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Delete.cshtml
@@ -1,0 +1,50 @@
+﻿@model BangazonWorkforce.Models.TrainingProgram
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h1>Delete</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>TrainingProgram</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Id)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Id)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.StartDate)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.StartDate)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.EndDate)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.EndDate)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.MaxAttendees)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.MaxAttendees)
+        </dd>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="submit" value="Delete" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+</div>

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Delete.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Delete.cshtml
@@ -1,4 +1,7 @@
-﻿@model BangazonWorkforce.Models.TrainingProgram
+﻿@*Author: Chris Morgan
+The purpose of the training program delete view is to render a confirmation page that the user can confirm a training program to delete.*@
+
+@model BangazonWorkforce.Models.TrainingProgram
 
 @{
     ViewData["Title"] = "Delete";
@@ -11,38 +14,38 @@
     <h4>TrainingProgram</h4>
     <hr />
     <dl class="row">
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Id)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.Id)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Name)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.Name)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.StartDate)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.StartDate)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.EndDate)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.EndDate)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.MaxAttendees)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.MaxAttendees)
         </dd>
     </dl>
-    
+
     <form asp-action="Delete">
         <input type="submit" value="Delete" class="btn btn-danger" /> |
         <a asp-action="Index">Back to List</a>


### PR DESCRIPTION
# Description

This pull request contains the delete functionality for training programs. I've created two methods in the TrainingProgramsController.cs file that are used for the delete. Also I've created a delete view.



Fixes Issue # [(12)](https://github.com/rioting-daisies/BangazonWorkforce/issues/12)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

- [ ] This change requires a documentation update

# Testing Instructions

1. `git fetch --all`
2. `git checkout blue-trainingDelete`
3. Run the application and navigate to the training program index.
4. Create a new program and delete it, confirm that the index view is updated without the deleted program.
5. If you want, add an employee to an existing training program in your database with Azure, then try to delete this training program to confirm that the items in the EmployeeTraining join table have been deleted as well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
