### PR TITLE
Views and methods to list the training programs who have already happened

### DIFF
--- a/BangazonWorkforce/BangazonWorkforce/Controllers/DepartmentsController.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Controllers/DepartmentsController.cs
@@ -28,6 +28,7 @@ namespace BangazonWorkforce.Controllers
                 return new SqlConnection(_config.GetConnectionString("DefaultConnection"));
             }
         }
+        //The Get all departments method in the departmentscontroller is used to display all departments with their name, budget, and a count of their total employees 
         // GET: Department
         public ActionResult Index()
         {
@@ -62,7 +63,7 @@ namespace BangazonWorkforce.Controllers
             }
 
         }
-
+        // The department details method is used to display the name budget and a list of the departments employees with their full names for the specefic department
         // GET: Department/Details/5
         public ActionResult Details(int id)
            {
@@ -80,7 +81,7 @@ namespace BangazonWorkforce.Controllers
         {
             return View();
         }
-
+        // Simple create method for departmentController to create a new department with a Name and a Budget
         // POST: Department/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -156,6 +157,8 @@ namespace BangazonWorkforce.Controllers
                 return View();
             }
         }
+
+        //Method for getting a specefic department by its Id
         private Department GetDepartmentById(int id)
         {
             using (SqlConnection conn = Connection)

--- a/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
@@ -96,6 +96,26 @@ namespace BangazonWorkforce.Controllers
 
         }
 
+        // GET: TrainingPrograms/Details/5
+        public ActionResult PastDetails(int id)
+        {
+            TrainingProgram trainingProgram = GetPastTrainingProgram(id);
+
+            if (trainingProgram == null)
+            {
+                return NotFound();
+            }
+            else
+            {
+                TrainingProgramDetailsViewModel viewModel = new TrainingProgramDetailsViewModel(id, _config.GetConnectionString("DefaultConnection"));
+
+                viewModel.TrainingProgram = trainingProgram;
+
+                return View(viewModel);
+            }
+
+        }
+
         // This is the initial get for the create functionality and builds the form
         // GET: TrainingPrograms/Create
         public ActionResult Create()
@@ -286,6 +306,49 @@ namespace BangazonWorkforce.Controllers
                             EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
                             MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
                         };  
+                    }
+
+                    reader.Close();
+
+                    return trainingProgram;
+
+                }
+            }
+        }
+        private TrainingProgram GetPastTrainingProgram(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT
+                                            t.Id,
+                                            t.Name,
+                                            t.StartDate,
+                                            t.EndDate,
+                                            t.MaxAttendees
+                                        FROM TrainingProgram t
+                                        WHERE t.StartDate < GetDate()
+                                        AND t.Id = @id";
+
+                    cmd.Parameters.Add(new SqlParameter("@id", id));
+
+                    TrainingProgram trainingProgram = null;
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    if (reader.Read())
+                    {
+                        trainingProgram = new TrainingProgram
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
+                        };
                     }
 
                     reader.Close();

--- a/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Controllers/TrainingProgramsController.cs
@@ -1,4 +1,4 @@
-﻿// Author: Chris Morgan
+﻿// Author: Chris Morgan and Clifton Matuszewski
 // The purpose of the TrainingProgramsController is to hold all of the methods that deal with the TrainingProgram database actions / CRUD functionality within the application
 
 using System;
@@ -207,6 +207,49 @@ namespace BangazonWorkforce.Controllers
             {
                 return View();
             }
+        }
+        // The index() method is a GetAllTrainingDepartments method. It only returns training departments that haven't started yet. The result is passed into the Index view for Employees
+        // GET: TrainingPrograms
+        public ActionResult PastTrainingProgramsIndex()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT
+                                            t.Id,
+                                            t.Name,
+                                            t.StartDate,
+                                            t.EndDate,
+                                            t.MaxAttendees
+                                        FROM TrainingProgram t
+                                        WHERE t.StartDate < GetDate()";
+
+                    List<TrainingProgram> trainingPrograms = new List<TrainingProgram>();
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    while (reader.Read())
+                    {
+                        TrainingProgram trainingProgram = new TrainingProgram
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
+                        };
+
+                        trainingPrograms.Add(trainingProgram);
+                    }
+
+                    return View(trainingPrograms);
+
+                }
+            }
+
         }
 
         private TrainingProgram GetTrainingProgramById(int id)

--- a/BangazonWorkforce/BangazonWorkforce/Models/Department.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Models/Department.cs
@@ -1,4 +1,7 @@
-﻿﻿using System;
+﻿//Author Clifton Matuszewski
+//Department class to hold its properties and also determine the fields that are required for departments to be created﻿
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/BangazonWorkforce/BangazonWorkforce/Models/ViewModels/DepartmentEmployeesViewModel.cs
+++ b/BangazonWorkforce/BangazonWorkforce/Models/ViewModels/DepartmentEmployeesViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿//Author Clifton Matuszewski
+//The purpose of this viewModel is to hold all of the properties for displaying Specefic Departments by their Id's its neccesary in order to access the list of the departments Employees
+
+using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
@@ -8,6 +11,7 @@ namespace BangazonWorkforce.Models.ViewModels
 {
     public class DepartmentEmployeesViewModel
     {
+
         public List<Employee> employees { get; set; }
         public Department department { get; set; }
 
@@ -28,7 +32,7 @@ namespace BangazonWorkforce.Models.ViewModels
             GetDepartmentEmployees(id);
 
         }
-
+        //Method to get a specefic Department by its Id spitting back the Name and the budget
         private Department GetDepartmentById(int id)
         {
             using (SqlConnection conn = Connection)
@@ -58,7 +62,7 @@ namespace BangazonWorkforce.Models.ViewModels
                 }
             }
         }
-
+        //Method to get a Specefic Departments list of employees with their First and Last Names
         private void GetDepartmentEmployees(int id)
         {
             using (SqlConnection conn = Connection)

--- a/BangazonWorkforce/BangazonWorkforce/Views/Shared/_Layout.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/Shared/_Layout.cshtml
@@ -38,7 +38,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Employees" asp-action="Index">Employees</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Department" asp-action="Index">Departments</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Departments" asp-action="Index">Departments</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="TrainingPrograms" asp-action="Index">Training Programs</a>

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Index.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/Index.cshtml
@@ -9,6 +9,9 @@
 <p>
     <a asp-action="Create">Create New</a>
 </p>
+<p>
+    <a asp-action="PastTrainingProgramsIndex">Past Training Programs</a>
+</p>
 <table class="table">
     <thead>
         <tr>
@@ -55,8 +58,7 @@
                 @Html.ActionLink("Delete", "Delete", new { id = item.Id })
                 
             </td>
-            <td><a asp-action="PastTrainingProgramsIndex">Past Training Programs</a>
-            </td>
+            
         </tr>
 }
     </tbody>

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastDetails.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastDetails.cshtml
@@ -79,6 +79,6 @@
 </div>
 <div>
     @Html.ActionLink("Edit", "Edit", new { id = Model.TrainingProgram.Id }) |
-    <a asp-action="Index">Back to List</a>
+    <a asp-action="PastTrainingProgramsIndex">Back to List</a>
 </div>
 

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastDetails.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastDetails.cshtml
@@ -78,7 +78,7 @@
     </dl>
 </div>
 <div>
-    @Html.ActionLink("Edit", "Edit", new { id = Model.TrainingProgram.Id }) |
+   
     <a asp-action="PastTrainingProgramsIndex">Back to List</a>
 </div>
 

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastDetails.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastDetails.cshtml
@@ -1,0 +1,84 @@
+﻿@model BangazonWorkforce.Models.ViewModels.TrainingProgramDetailsViewModel
+
+@{
+    ViewData["Title"] = "PastDetails";
+}
+
+<h1>Past Details</h1>
+
+<div>
+    <h4>Training Program</h4>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.TrainingProgram.Id)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.TrainingProgram.Id)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.TrainingProgram.Name)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.TrainingProgram.Name)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.TrainingProgram.StartDate)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.TrainingProgram.StartDate)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.TrainingProgram.EndDate)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.TrainingProgram.EndDate)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.TrainingProgram.MaxAttendees)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.TrainingProgram.MaxAttendees)
+        </dd>
+
+
+    </dl>
+    <h4>Employees Attending Training Program</h4>
+    <hr />
+    <dl class="row">
+
+        @foreach (var employee in Model.Employees)
+        {
+
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => employee.FirstName)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => employee.FirstName)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => employee.LastName)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => employee.LastName)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => employee.DepartmentId)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => employee.DepartmentId)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => employee.IsSupervisor)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => employee.IsSupervisor)
+            </dd>
+        }
+    </dl>
+</div>
+<div>
+    @Html.ActionLink("Edit", "Edit", new { id = Model.TrainingProgram.Id }) |
+    <a asp-action="Index">Back to List</a>
+</div>
+

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
@@ -1,10 +1,10 @@
 ﻿@model IEnumerable<BangazonWorkforce.Models.TrainingProgram>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "PastTrainingProgramsIndex";
 }
 
-<h1>Index</h1>
+<h1>PastTrainingProgramsIndex</h1>
 
 <p>
     <a asp-action="Create">Create New</a>
@@ -49,13 +49,12 @@
                 @Html.DisplayFor(modelItem => item.MaxAttendees)
             </td>
             <td>
-
-                @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
-                @Html.ActionLink("Details", "Details", new { id = item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new { id = item.Id })
-                
+                @Html.ActionLink("Edit", "Edit", new { /* id=item.PrimaryKey */ }) |
+                @Html.ActionLink("Details", "Details", new { /* id=item.PrimaryKey */ }) |
+                @Html.ActionLink("Delete", "Delete", new { /* id=item.PrimaryKey */ })
             </td>
-            <td><a asp-action="PastTrainingProgramsIndex">Past Training Programs</a>
+            <td>
+                <a asp-action="Index">Back to List</a>
             </td>
         </tr>
 }

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
@@ -9,6 +9,9 @@
 <p>
     <a asp-action="Create">Create New</a>
 </p>
+<p>
+    <a asp-action="Index">Back to List</a>
+</p>
 <table class="table">
     <thead>
         <tr>
@@ -49,14 +52,12 @@
                 @Html.DisplayFor(modelItem => item.MaxAttendees)
             </td>
             <td>
-                @Html.ActionLink("Edit", "Edit", new { /* id=item.PrimaryKey */ }) |
+               
                 @Html.ActionLink("PastDetails", "PastDetails", new { id = item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new { /* id=item.PrimaryKey */ })
+               
             </td>
         </tr>
 }
     </tbody>
 </table>
-            <div>
-                <a asp-action="Index">Back to List</a>
-            </div>
+            

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
@@ -50,7 +50,7 @@
             </td>
             <td>
                 @Html.ActionLink("Edit", "Edit", new { /* id=item.PrimaryKey */ }) |
-                @Html.ActionLink("Details", "Details", new { id = item.Id }) |
+                @Html.ActionLink("PastDetails", "PastDetails", new { id = item.Id }) |
                 @Html.ActionLink("Delete", "Delete", new { /* id=item.PrimaryKey */ })
             </td>
         </tr>

--- a/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
+++ b/BangazonWorkforce/BangazonWorkforce/Views/TrainingPrograms/PastTrainingProgramsIndex.cshtml
@@ -50,13 +50,13 @@
             </td>
             <td>
                 @Html.ActionLink("Edit", "Edit", new { /* id=item.PrimaryKey */ }) |
-                @Html.ActionLink("Details", "Details", new { /* id=item.PrimaryKey */ }) |
+                @Html.ActionLink("Details", "Details", new { id = item.Id }) |
                 @Html.ActionLink("Delete", "Delete", new { /* id=item.PrimaryKey */ })
-            </td>
-            <td>
-                <a asp-action="Index">Back to List</a>
             </td>
         </tr>
 }
     </tbody>
 </table>
+            <div>
+                <a asp-action="Index">Back to List</a>
+            </div>


### PR DESCRIPTION
# Description

Created link on training programs to allow users to view training programs that have already happened as well as the details and employees that attended the program.



Fixes Issue # https://github.com/rioting-daisies/BangazonWorkforce/issues/16 and https://github.com/rioting-daisies/BangazonWorkforce/issues/17

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

Git fetch --all and checkout cm-past-training
Run Bangazon and click the training programs tab 
There should be a past training programs link that takes you to the list of the past programs
On that page click the details of a training program it should display the program as well as a list of employees.



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works
